### PR TITLE
feat: `validate-ecs-containers-nonprivileged` policy

### DIFF
--- a/validate-ecs-containers-nonprivileged/README.md
+++ b/validate-ecs-containers-nonprivileged/README.md
@@ -1,0 +1,63 @@
+# ECS containers should run as non-privileged
+
+It is important to ensure that ECS containers run without elevated privileges to enhance security. The policy checks the privileged parameter in the container definition and raises a concern if it is set to `true`. When a container is granted elevated permissions (similar to the root user) by having privileged set to true, it poses potential security risks on the host container instance.
+
+We advise against running containers with elevated privileges, as this may compromise the overall security of your ECS task definitions. It is recommended to avoid using privileged and, instead, specify precise privileges using specific parameters. This approach allows for a more controlled and secure execution environment, minimizing the risks associated with running containers with unnecessary elevated privileges.
+
+### Policy Validation Testing Instructions
+
+To evaluate and test the policy ensuring if the privileged parameter in the container definition is set to `false` (is default) in the Terraform plan payload, follow the steps outlined below:
+
+Make sure you have `kyverno-json` installed on the machine.
+
+1. **Initialize Terraform:**
+    ```bash
+    terraform init
+    ```
+
+2. **Create Binary Terraform Plan:**
+    ```bash
+    terraform plan -out tfplan.binary
+    ```
+
+3. **Convert Binary to JSON Payload:**
+    ```bash
+    terraform show -json tfplan.binary | jq > payload.json
+    ```
+
+4. **Test the Policy with Kyverno:**
+    ```
+   kyverno-json scan --payload payload.json --policy policy.yaml
+    ```
+    
+    a. **Test Policy Against Valid Payload:**
+    ```
+    kyverno-json scan --policy validate-ecs-containers-nonprivileged.yaml --payload policy-test/good-payload.json
+    ```
+
+    This produces the output:
+    ```
+    Loading policies ...
+    Loading payload ...
+    Pre processing ...
+    Running ( evaluating 1 resource against 1 policy ) ...
+    - validate-ecs-containers-nonprivileged / validate-ecs-containers-nonprivileged /  PASSED
+    Done
+    ```
+
+    b. **Test Against Invalid Payload:**
+    ```
+    kyverno-json scan --policy validate-ecs-containers-nonprivileged.yaml --payload policy-test/bad-payload.json
+    ```
+
+    This produces the output:
+    ```
+    Loading policies ...
+    Loading payload ...
+    Pre processing ...
+    Running ( evaluating 1 resource against 1 policy ) ...
+    - validate-ecs-containers-nonprivileged / validate-ecs-containers-nonprivileged /  FAILED: Containers must be set to non privileged.: any[0].check.(configuration.root_module.module_calls.ecs_container_definition.expressions.privileged || `{}` | length(keys(@)) > `0`): Invalid value: true: Expected value: false; any[1].check.configuration.root_module.module_calls.ecs_container_definition.expressions.privileged.constant_value: Invalid value: true: Expected value: false
+    Done
+    ```
+
+---

--- a/validate-ecs-containers-nonprivileged/policy-test/bad-payload.json
+++ b/validate-ecs-containers-nonprivileged/policy-test/bad-payload.json
@@ -1,0 +1,472 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.6.6-dev",
+    "planned_values": {
+      "root_module": {
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+                "mode": "managed",
+                "type": "aws_cloudwatch_log_group",
+                "name": "this",
+                "index": 0,
+                "provider_name": "registry.terraform.io/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "kms_key_id": null,
+                  "name": "/aws/ecs//example",
+                  "retention_in_days": 30,
+                  "skip_destroy": false,
+                  "tags": {
+                    "Environment": "dev",
+                    "Terraform": "true"
+                  },
+                  "tags_all": {
+                    "Environment": "dev",
+                    "Terraform": "true"
+                  }
+                },
+                "sensitive_values": {
+                  "tags": {},
+                  "tags_all": {}
+                }
+              }
+            ],
+            "address": "module.ecs_container_definition"
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "module_address": "module.ecs_container_definition",
+        "mode": "managed",
+        "type": "aws_cloudwatch_log_group",
+        "name": "this",
+        "index": 0,
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "kms_key_id": null,
+            "name": "/aws/ecs//example",
+            "retention_in_days": 30,
+            "skip_destroy": false,
+            "tags": {
+              "Environment": "dev",
+              "Terraform": "true"
+            },
+            "tags_all": {
+              "Environment": "dev",
+              "Terraform": "true"
+            }
+          },
+          "after_unknown": {
+            "arn": true,
+            "id": true,
+            "name_prefix": true,
+            "tags": {},
+            "tags_all": {}
+          },
+          "before_sensitive": false,
+          "after_sensitive": {
+            "tags": {},
+            "tags_all": {}
+          }
+        }
+      }
+    ],
+    "prior_state": {
+      "format_version": "1.0",
+      "terraform_version": "1.6.6",
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.ecs_container_definition.data.aws_region.current",
+                  "mode": "data",
+                  "type": "aws_region",
+                  "name": "current",
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "description": "US West (N. California)",
+                    "endpoint": "ec2.us-west-1.amazonaws.com",
+                    "id": "us-west-1",
+                    "name": "us-west-1"
+                  },
+                  "sensitive_values": {}
+                }
+              ],
+              "address": "module.ecs_container_definition"
+            }
+          ]
+        }
+      }
+    },
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "full_name": "registry.terraform.io/hashicorp/aws",
+          "version_constraint": "~> 4.0",
+          "expressions": {
+            "profile": {
+              "constant_value": "fyka"
+            },
+            "region": {
+              "constant_value": "us-west-1"
+            }
+          }
+        },
+        "docker": {
+          "name": "docker",
+          "full_name": "registry.terraform.io/kreuzwerker/docker",
+          "version_constraint": "~> 2.20.0"
+        }
+      },
+      "root_module": {
+        "module_calls": {
+          "ecs_container_definition": {
+            "source": "terraform-aws-modules/ecs/aws//modules/container-definition",
+            "expressions": {
+              "image": {
+                "constant_value": "public.ecr.aws/aws-containers/ecsdemo-frontend:776fd50"
+              },
+              "name": {
+                "constant_value": "example"
+              },
+              "port_mappings": {
+                "constant_value": [
+                  {
+                    "containerPort": 80,
+                    "name": "ecs-sample",
+                    "protocol": "tcp"
+                  }
+                ]
+              },
+              "privileged": {
+                "constant_value": true
+              },
+              "tags": {
+                "constant_value": {
+                  "Environment": "dev",
+                  "Terraform": "true"
+                }
+              }
+            },
+            "module": {
+              "outputs": {
+                "cloudwatch_log_group_arn": {
+                  "expression": {
+                    "references": [
+                      "aws_cloudwatch_log_group.this[0].arn",
+                      "aws_cloudwatch_log_group.this[0]",
+                      "aws_cloudwatch_log_group.this"
+                    ]
+                  },
+                  "description": "Arn of cloudwatch log group created"
+                },
+                "cloudwatch_log_group_name": {
+                  "expression": {
+                    "references": [
+                      "aws_cloudwatch_log_group.this[0].name",
+                      "aws_cloudwatch_log_group.this[0]",
+                      "aws_cloudwatch_log_group.this"
+                    ]
+                  },
+                  "description": "Name of cloudwatch log group created"
+                },
+                "container_definition": {
+                  "expression": {
+                    "references": [
+                      "local.container_definition"
+                    ]
+                  },
+                  "description": "Container definition"
+                }
+              },
+              "resources": [
+                {
+                  "address": "aws_cloudwatch_log_group.this",
+                  "mode": "managed",
+                  "type": "aws_cloudwatch_log_group",
+                  "name": "this",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "kms_key_id": {
+                      "references": [
+                        "var.cloudwatch_log_group_kms_key_id"
+                      ]
+                    },
+                    "name": {
+                      "references": [
+                        "var.cloudwatch_log_group_use_name_prefix",
+                        "local.log_group_name"
+                      ]
+                    },
+                    "name_prefix": {
+                      "references": [
+                        "var.cloudwatch_log_group_use_name_prefix",
+                        "local.log_group_name"
+                      ]
+                    },
+                    "retention_in_days": {
+                      "references": [
+                        "var.cloudwatch_log_group_retention_in_days"
+                      ]
+                    },
+                    "tags": {
+                      "references": [
+                        "var.tags"
+                      ]
+                    }
+                  },
+                  "schema_version": 0,
+                  "count_expression": {
+                    "references": [
+                      "var.create_cloudwatch_log_group",
+                      "var.enable_cloudwatch_logging"
+                    ]
+                  }
+                },
+                {
+                  "address": "data.aws_region.current",
+                  "mode": "data",
+                  "type": "aws_region",
+                  "name": "current",
+                  "provider_config_key": "aws",
+                  "schema_version": 0
+                }
+              ],
+              "variables": {
+                "cloudwatch_log_group_kms_key_id": {
+                  "default": null,
+                  "description": "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+                },
+                "cloudwatch_log_group_retention_in_days": {
+                  "default": 30,
+                  "description": "Number of days to retain log events. Default is 30 days"
+                },
+                "cloudwatch_log_group_use_name_prefix": {
+                  "default": false,
+                  "description": "Determines whether the log group name should be used as a prefix"
+                },
+                "command": {
+                  "default": [],
+                  "description": "The command that's passed to the container"
+                },
+                "cpu": {
+                  "default": null,
+                  "description": "The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of `cpu` of all containers in a task will need to be lower than the task-level cpu value"
+                },
+                "create_cloudwatch_log_group": {
+                  "default": true,
+                  "description": "Determines whether a log group is created by this module. If not, AWS will automatically create one if logging is enabled"
+                },
+                "dependencies": {
+                  "default": [],
+                  "description": "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY"
+                },
+                "disable_networking": {
+                  "default": null,
+                  "description": "When this parameter is true, networking is disabled within the container"
+                },
+                "dns_search_domains": {
+                  "default": [],
+                  "description": "Container DNS search domains. A list of DNS search domains that are presented to the container"
+                },
+                "dns_servers": {
+                  "default": [],
+                  "description": "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
+                },
+                "docker_labels": {
+                  "default": {},
+                  "description": "A key/value map of labels to add to the container"
+                },
+                "docker_security_options": {
+                  "default": [],
+                  "description": "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems. This field isn't valid for containers in tasks using the Fargate launch type"
+                },
+                "enable_cloudwatch_logging": {
+                  "default": true,
+                  "description": "Determines whether CloudWatch logging is configured for this container definition. Set to `false` to use other logging drivers"
+                },
+                "enable_execute_command": {
+                  "default": false,
+                  "description": "Specifies whether to enable Amazon ECS Exec for the tasks within the service"
+                },
+                "entrypoint": {
+                  "default": [],
+                  "description": "The entry point that is passed to the container"
+                },
+                "environment": {
+                  "default": [],
+                  "description": "The environment variables to pass to the container"
+                },
+                "environment_files": {
+                  "default": [],
+                  "description": "A list of files containing the environment variables to pass to a container"
+                },
+                "essential": {
+                  "default": null,
+                  "description": "If the `essential` parameter of a container is marked as `true`, and that container fails or stops for any reason, all other containers that are part of the task are stopped"
+                },
+                "extra_hosts": {
+                  "default": [],
+                  "description": "A list of hostnames and IP address mappings to append to the `/etc/hosts` file on the container"
+                },
+                "firelens_configuration": {
+                  "default": {},
+                  "description": "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more information, see [Custom Log Routing](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) in the Amazon Elastic Container Service Developer Guide"
+                },
+                "health_check": {
+                  "default": {},
+                  "description": "The container health check command and associated configuration parameters for the container. See [HealthCheck](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html)"
+                },
+                "hostname": {
+                  "default": null,
+                  "description": "The hostname to use for your container"
+                },
+                "image": {
+                  "default": null,
+                  "description": "The image used to start a container. This string is passed directly to the Docker daemon. By default, images in the Docker Hub registry are available. Other repositories are specified with either `repository-url/image:tag` or `repository-url/image@digest`"
+                },
+                "interactive": {
+                  "default": false,
+                  "description": "When this parameter is `true`, you can deploy containerized applications that require `stdin` or a `tty` to be allocated"
+                },
+                "links": {
+                  "default": [],
+                  "description": "The links parameter allows containers to communicate with each other without the need for port mappings. This parameter is only supported if the network mode of a task definition is `bridge`"
+                },
+                "linux_parameters": {
+                  "default": {},
+                  "description": "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more information see [KernelCapabilities](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html)"
+                },
+                "log_configuration": {
+                  "default": {},
+                  "description": "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more information see [KernelCapabilities](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html)"
+                },
+                "memory": {
+                  "default": null,
+                  "description": "The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed. The total amount of memory reserved for all containers within a task must be lower than the task `memory` value, if one is specified"
+                },
+                "memory_reservation": {
+                  "default": null,
+                  "description": "The soft limit (in MiB) of memory to reserve for the container. When system memory is under heavy contention, Docker attempts to keep the container memory to this soft limit. However, your container can consume more memory when it needs to, up to either the hard limit specified with the `memory` parameter (if applicable), or all of the available memory on the container instance"
+                },
+                "mount_points": {
+                  "default": [],
+                  "description": "The mount points for data volumes in your container"
+                },
+                "name": {
+                  "default": null,
+                  "description": "The name of a container. If you're linking multiple containers together in a task definition, the name of one container can be entered in the links of another container to connect the containers. Up to 255 letters (uppercase and lowercase), numbers, underscores, and hyphens are allowed"
+                },
+                "operating_system_family": {
+                  "default": "LINUX",
+                  "description": "The OS family for task"
+                },
+                "port_mappings": {
+                  "default": [],
+                  "description": "The list of port mappings for the container. Port mappings allow containers to access ports on the host container instance to send or receive traffic. For task definitions that use the awsvpc network mode, only specify the containerPort. The hostPort can be left blank or it must be the same value as the containerPort"
+                },
+                "privileged": {
+                  "default": false,
+                  "description": "When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user)"
+                },
+                "pseudo_terminal": {
+                  "default": false,
+                  "description": "When this parameter is true, a `TTY` is allocated"
+                },
+                "readonly_root_filesystem": {
+                  "default": true,
+                  "description": "When this parameter is true, the container is given read-only access to its root file system"
+                },
+                "repository_credentials": {
+                  "default": {},
+                  "description": "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
+                },
+                "resource_requirements": {
+                  "default": [],
+                  "description": "The type and amount of a resource to assign to a container. The only supported resource is a GPU"
+                },
+                "secrets": {
+                  "default": [],
+                  "description": "The secrets to pass to the container. For more information, see [Specifying Sensitive Data](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html) in the Amazon Elastic Container Service Developer Guide"
+                },
+                "service": {
+                  "default": "",
+                  "description": "The name of the service that the container definition is associated with"
+                },
+                "start_timeout": {
+                  "default": 30,
+                  "description": "Time duration (in seconds) to wait before giving up on resolving dependencies for a container"
+                },
+                "stop_timeout": {
+                  "default": 120,
+                  "description": "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
+                },
+                "system_controls": {
+                  "default": [],
+                  "description": "A list of namespaced kernel parameters to set in the container"
+                },
+                "tags": {
+                  "default": {},
+                  "description": "A map of tags to add to all resources"
+                },
+                "ulimits": {
+                  "default": [],
+                  "description": "A list of ulimits to set in the container. If a ulimit value is specified in a task definition, it overrides the default values set by Docker"
+                },
+                "user": {
+                  "default": null,
+                  "description": "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set"
+                },
+                "volumes_from": {
+                  "default": [],
+                  "description": "Data volumes to mount from another container"
+                },
+                "working_directory": {
+                  "default": null,
+                  "description": "The working directory to run commands inside the container"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "relevant_attributes": [
+      {
+        "resource": "module.ecs_container_definition.data.aws_region.current",
+        "attribute": [
+          "name"
+        ]
+      },
+      {
+        "resource": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "attribute": [
+          "name"
+        ]
+      },
+      {
+        "resource": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "attribute": [
+          "arn"
+        ]
+      }
+    ],
+    "timestamp": "2024-01-15T18:19:18Z",
+    "errored": false
+  }
+  

--- a/validate-ecs-containers-nonprivileged/policy-test/good-payload.json
+++ b/validate-ecs-containers-nonprivileged/policy-test/good-payload.json
@@ -1,0 +1,472 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.6.6-dev",
+    "planned_values": {
+      "root_module": {
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+                "mode": "managed",
+                "type": "aws_cloudwatch_log_group",
+                "name": "this",
+                "index": 0,
+                "provider_name": "registry.terraform.io/hashicorp/aws",
+                "schema_version": 0,
+                "values": {
+                  "kms_key_id": null,
+                  "name": "/aws/ecs//example",
+                  "retention_in_days": 30,
+                  "skip_destroy": false,
+                  "tags": {
+                    "Environment": "dev",
+                    "Terraform": "true"
+                  },
+                  "tags_all": {
+                    "Environment": "dev",
+                    "Terraform": "true"
+                  }
+                },
+                "sensitive_values": {
+                  "tags": {},
+                  "tags_all": {}
+                }
+              }
+            ],
+            "address": "module.ecs_container_definition"
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "module_address": "module.ecs_container_definition",
+        "mode": "managed",
+        "type": "aws_cloudwatch_log_group",
+        "name": "this",
+        "index": 0,
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "kms_key_id": null,
+            "name": "/aws/ecs//example",
+            "retention_in_days": 30,
+            "skip_destroy": false,
+            "tags": {
+              "Environment": "dev",
+              "Terraform": "true"
+            },
+            "tags_all": {
+              "Environment": "dev",
+              "Terraform": "true"
+            }
+          },
+          "after_unknown": {
+            "arn": true,
+            "id": true,
+            "name_prefix": true,
+            "tags": {},
+            "tags_all": {}
+          },
+          "before_sensitive": false,
+          "after_sensitive": {
+            "tags": {},
+            "tags_all": {}
+          }
+        }
+      }
+    ],
+    "prior_state": {
+      "format_version": "1.0",
+      "terraform_version": "1.6.6",
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.ecs_container_definition.data.aws_region.current",
+                  "mode": "data",
+                  "type": "aws_region",
+                  "name": "current",
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "description": "US West (N. California)",
+                    "endpoint": "ec2.us-west-1.amazonaws.com",
+                    "id": "us-west-1",
+                    "name": "us-west-1"
+                  },
+                  "sensitive_values": {}
+                }
+              ],
+              "address": "module.ecs_container_definition"
+            }
+          ]
+        }
+      }
+    },
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "full_name": "registry.terraform.io/hashicorp/aws",
+          "version_constraint": "~> 4.0",
+          "expressions": {
+            "profile": {
+              "constant_value": "fyka"
+            },
+            "region": {
+              "constant_value": "us-west-1"
+            }
+          }
+        },
+        "docker": {
+          "name": "docker",
+          "full_name": "registry.terraform.io/kreuzwerker/docker",
+          "version_constraint": "~> 2.20.0"
+        }
+      },
+      "root_module": {
+        "module_calls": {
+          "ecs_container_definition": {
+            "source": "terraform-aws-modules/ecs/aws//modules/container-definition",
+            "expressions": {
+              "image": {
+                "constant_value": "public.ecr.aws/aws-containers/ecsdemo-frontend:776fd50"
+              },
+              "name": {
+                "constant_value": "example"
+              },
+              "port_mappings": {
+                "constant_value": [
+                  {
+                    "containerPort": 80,
+                    "name": "ecs-sample",
+                    "protocol": "tcp"
+                  }
+                ]
+              },
+              "privileged": {
+                "constant_value": false
+              },
+              "tags": {
+                "constant_value": {
+                  "Environment": "dev",
+                  "Terraform": "true"
+                }
+              }
+            },
+            "module": {
+              "outputs": {
+                "cloudwatch_log_group_arn": {
+                  "expression": {
+                    "references": [
+                      "aws_cloudwatch_log_group.this[0].arn",
+                      "aws_cloudwatch_log_group.this[0]",
+                      "aws_cloudwatch_log_group.this"
+                    ]
+                  },
+                  "description": "Arn of cloudwatch log group created"
+                },
+                "cloudwatch_log_group_name": {
+                  "expression": {
+                    "references": [
+                      "aws_cloudwatch_log_group.this[0].name",
+                      "aws_cloudwatch_log_group.this[0]",
+                      "aws_cloudwatch_log_group.this"
+                    ]
+                  },
+                  "description": "Name of cloudwatch log group created"
+                },
+                "container_definition": {
+                  "expression": {
+                    "references": [
+                      "local.container_definition"
+                    ]
+                  },
+                  "description": "Container definition"
+                }
+              },
+              "resources": [
+                {
+                  "address": "aws_cloudwatch_log_group.this",
+                  "mode": "managed",
+                  "type": "aws_cloudwatch_log_group",
+                  "name": "this",
+                  "provider_config_key": "aws",
+                  "expressions": {
+                    "kms_key_id": {
+                      "references": [
+                        "var.cloudwatch_log_group_kms_key_id"
+                      ]
+                    },
+                    "name": {
+                      "references": [
+                        "var.cloudwatch_log_group_use_name_prefix",
+                        "local.log_group_name"
+                      ]
+                    },
+                    "name_prefix": {
+                      "references": [
+                        "var.cloudwatch_log_group_use_name_prefix",
+                        "local.log_group_name"
+                      ]
+                    },
+                    "retention_in_days": {
+                      "references": [
+                        "var.cloudwatch_log_group_retention_in_days"
+                      ]
+                    },
+                    "tags": {
+                      "references": [
+                        "var.tags"
+                      ]
+                    }
+                  },
+                  "schema_version": 0,
+                  "count_expression": {
+                    "references": [
+                      "var.create_cloudwatch_log_group",
+                      "var.enable_cloudwatch_logging"
+                    ]
+                  }
+                },
+                {
+                  "address": "data.aws_region.current",
+                  "mode": "data",
+                  "type": "aws_region",
+                  "name": "current",
+                  "provider_config_key": "aws",
+                  "schema_version": 0
+                }
+              ],
+              "variables": {
+                "cloudwatch_log_group_kms_key_id": {
+                  "default": null,
+                  "description": "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+                },
+                "cloudwatch_log_group_retention_in_days": {
+                  "default": 30,
+                  "description": "Number of days to retain log events. Default is 30 days"
+                },
+                "cloudwatch_log_group_use_name_prefix": {
+                  "default": false,
+                  "description": "Determines whether the log group name should be used as a prefix"
+                },
+                "command": {
+                  "default": [],
+                  "description": "The command that's passed to the container"
+                },
+                "cpu": {
+                  "default": null,
+                  "description": "The number of cpu units to reserve for the container. This is optional for tasks using Fargate launch type and the total amount of `cpu` of all containers in a task will need to be lower than the task-level cpu value"
+                },
+                "create_cloudwatch_log_group": {
+                  "default": true,
+                  "description": "Determines whether a log group is created by this module. If not, AWS will automatically create one if logging is enabled"
+                },
+                "dependencies": {
+                  "default": [],
+                  "description": "The dependencies defined for container startup and shutdown. A container can contain multiple dependencies. When a dependency is defined for container startup, for container shutdown it is reversed. The condition can be one of START, COMPLETE, SUCCESS or HEALTHY"
+                },
+                "disable_networking": {
+                  "default": null,
+                  "description": "When this parameter is true, networking is disabled within the container"
+                },
+                "dns_search_domains": {
+                  "default": [],
+                  "description": "Container DNS search domains. A list of DNS search domains that are presented to the container"
+                },
+                "dns_servers": {
+                  "default": [],
+                  "description": "Container DNS servers. This is a list of strings specifying the IP addresses of the DNS servers"
+                },
+                "docker_labels": {
+                  "default": {},
+                  "description": "A key/value map of labels to add to the container"
+                },
+                "docker_security_options": {
+                  "default": [],
+                  "description": "A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems. This field isn't valid for containers in tasks using the Fargate launch type"
+                },
+                "enable_cloudwatch_logging": {
+                  "default": true,
+                  "description": "Determines whether CloudWatch logging is configured for this container definition. Set to `false` to use other logging drivers"
+                },
+                "enable_execute_command": {
+                  "default": false,
+                  "description": "Specifies whether to enable Amazon ECS Exec for the tasks within the service"
+                },
+                "entrypoint": {
+                  "default": [],
+                  "description": "The entry point that is passed to the container"
+                },
+                "environment": {
+                  "default": [],
+                  "description": "The environment variables to pass to the container"
+                },
+                "environment_files": {
+                  "default": [],
+                  "description": "A list of files containing the environment variables to pass to a container"
+                },
+                "essential": {
+                  "default": null,
+                  "description": "If the `essential` parameter of a container is marked as `true`, and that container fails or stops for any reason, all other containers that are part of the task are stopped"
+                },
+                "extra_hosts": {
+                  "default": [],
+                  "description": "A list of hostnames and IP address mappings to append to the `/etc/hosts` file on the container"
+                },
+                "firelens_configuration": {
+                  "default": {},
+                  "description": "The FireLens configuration for the container. This is used to specify and configure a log router for container logs. For more information, see [Custom Log Routing](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) in the Amazon Elastic Container Service Developer Guide"
+                },
+                "health_check": {
+                  "default": {},
+                  "description": "The container health check command and associated configuration parameters for the container. See [HealthCheck](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html)"
+                },
+                "hostname": {
+                  "default": null,
+                  "description": "The hostname to use for your container"
+                },
+                "image": {
+                  "default": null,
+                  "description": "The image used to start a container. This string is passed directly to the Docker daemon. By default, images in the Docker Hub registry are available. Other repositories are specified with either `repository-url/image:tag` or `repository-url/image@digest`"
+                },
+                "interactive": {
+                  "default": false,
+                  "description": "When this parameter is `true`, you can deploy containerized applications that require `stdin` or a `tty` to be allocated"
+                },
+                "links": {
+                  "default": [],
+                  "description": "The links parameter allows containers to communicate with each other without the need for port mappings. This parameter is only supported if the network mode of a task definition is `bridge`"
+                },
+                "linux_parameters": {
+                  "default": {},
+                  "description": "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more information see [KernelCapabilities](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html)"
+                },
+                "log_configuration": {
+                  "default": {},
+                  "description": "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more information see [KernelCapabilities](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html)"
+                },
+                "memory": {
+                  "default": null,
+                  "description": "The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed. The total amount of memory reserved for all containers within a task must be lower than the task `memory` value, if one is specified"
+                },
+                "memory_reservation": {
+                  "default": null,
+                  "description": "The soft limit (in MiB) of memory to reserve for the container. When system memory is under heavy contention, Docker attempts to keep the container memory to this soft limit. However, your container can consume more memory when it needs to, up to either the hard limit specified with the `memory` parameter (if applicable), or all of the available memory on the container instance"
+                },
+                "mount_points": {
+                  "default": [],
+                  "description": "The mount points for data volumes in your container"
+                },
+                "name": {
+                  "default": null,
+                  "description": "The name of a container. If you're linking multiple containers together in a task definition, the name of one container can be entered in the links of another container to connect the containers. Up to 255 letters (uppercase and lowercase), numbers, underscores, and hyphens are allowed"
+                },
+                "operating_system_family": {
+                  "default": "LINUX",
+                  "description": "The OS family for task"
+                },
+                "port_mappings": {
+                  "default": [],
+                  "description": "The list of port mappings for the container. Port mappings allow containers to access ports on the host container instance to send or receive traffic. For task definitions that use the awsvpc network mode, only specify the containerPort. The hostPort can be left blank or it must be the same value as the containerPort"
+                },
+                "privileged": {
+                  "default": false,
+                  "description": "When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user)"
+                },
+                "pseudo_terminal": {
+                  "default": false,
+                  "description": "When this parameter is true, a `TTY` is allocated"
+                },
+                "readonly_root_filesystem": {
+                  "default": true,
+                  "description": "When this parameter is true, the container is given read-only access to its root file system"
+                },
+                "repository_credentials": {
+                  "default": {},
+                  "description": "Container repository credentials; required when using a private repo.  This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
+                },
+                "resource_requirements": {
+                  "default": [],
+                  "description": "The type and amount of a resource to assign to a container. The only supported resource is a GPU"
+                },
+                "secrets": {
+                  "default": [],
+                  "description": "The secrets to pass to the container. For more information, see [Specifying Sensitive Data](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html) in the Amazon Elastic Container Service Developer Guide"
+                },
+                "service": {
+                  "default": "",
+                  "description": "The name of the service that the container definition is associated with"
+                },
+                "start_timeout": {
+                  "default": 30,
+                  "description": "Time duration (in seconds) to wait before giving up on resolving dependencies for a container"
+                },
+                "stop_timeout": {
+                  "default": 120,
+                  "description": "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
+                },
+                "system_controls": {
+                  "default": [],
+                  "description": "A list of namespaced kernel parameters to set in the container"
+                },
+                "tags": {
+                  "default": {},
+                  "description": "A map of tags to add to all resources"
+                },
+                "ulimits": {
+                  "default": [],
+                  "description": "A list of ulimits to set in the container. If a ulimit value is specified in a task definition, it overrides the default values set by Docker"
+                },
+                "user": {
+                  "default": null,
+                  "description": "The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set"
+                },
+                "volumes_from": {
+                  "default": [],
+                  "description": "Data volumes to mount from another container"
+                },
+                "working_directory": {
+                  "default": null,
+                  "description": "The working directory to run commands inside the container"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "relevant_attributes": [
+      {
+        "resource": "module.ecs_container_definition.data.aws_region.current",
+        "attribute": [
+          "name"
+        ]
+      },
+      {
+        "resource": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "attribute": [
+          "name"
+        ]
+      },
+      {
+        "resource": "module.ecs_container_definition.aws_cloudwatch_log_group.this[0]",
+        "attribute": [
+          "arn"
+        ]
+      }
+    ],
+    "timestamp": "2024-01-15T18:19:18Z",
+    "errored": false
+  }
+  

--- a/validate-ecs-containers-nonprivileged/policy-test/terraform-code/main.tf
+++ b/validate-ecs-containers-nonprivileged/policy-test/terraform-code/main.tf
@@ -1,0 +1,21 @@
+module "ecs_container_definition" {
+  source = "terraform-aws-modules/ecs/aws//modules/container-definition"
+  name      = "example"
+  # cpu       = 512
+  # memory    = 1024
+  # essential = true
+  privileged = false
+  image     = "public.ecr.aws/aws-containers/ecsdemo-frontend:776fd50"
+  port_mappings = [
+    {
+      name          = "ecs-sample"
+      containerPort = 80
+      protocol      = "tcp"
+    }
+  ]
+  
+  tags = {
+    Environment = "dev"
+    Terraform   = "true"
+  }
+}

--- a/validate-ecs-containers-nonprivileged/policy-test/terraform-code/providers.tf
+++ b/validate-ecs-containers-nonprivileged/policy-test/terraform-code/providers.tf
@@ -1,0 +1,22 @@
+# Setting up the configuration for using Docker and AWS providers
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.20.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configuring docker and AWS as providers
+provider "docker" {}
+
+provider "aws" {
+  region  = "us-west-1"
+  profile = "fyka"
+}

--- a/validate-ecs-containers-nonprivileged/validate-ecs-containers-nonprivileged.yaml
+++ b/validate-ecs-containers-nonprivileged/validate-ecs-containers-nonprivileged.yaml
@@ -1,0 +1,33 @@
+apiVersion: json.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: validate-ecs-containers-nonprivileged
+  labels:
+    ecs.aws.tags.kyverno.io: ecs-service
+  annotations:
+    policies.kyverno.io/title: Validate ECS containers are set to non privileged.
+    policies.kyverno.io/category: ECS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      When privileged is true, the container is given elevated permissions on the host container instance (similar to the root user). 
+      This policy checks if the privileged parameter in the container definition is set to false.
+    policies.nirmata.io/remediation-docs: ""
+    policies.nirmata.io/remediation: ""
+
+spec:
+  rules:
+    - name: validate-ecs-containers-nonprivileged
+      assert:
+        any:
+        - check:
+            (configuration.root_module.module_calls.ecs_container_definition.expressions.privileged || `{}` | length(keys(@)) > `0`): false
+          message: Containers must be set to non privileged.
+        - check:
+            configuration:
+                root_module:
+                    module_calls:
+                        ecs_container_definition:
+                            expressions:
+                                privileged:
+                                    constant_value: false
+                                    


### PR DESCRIPTION
| Category                | AWS ECS Best Practices       | 
|-------------------------|-----------------------------| 
| Policy                  | validate-ecs-containers-nonprivileged  | 
| Rule                    | validate-ecs-containers-nonprivileged  | 
| Severity                | medium                      | 
| Description            | When privileged is true, the container is given elevated permissions on the host container instance (similar to the root user). This policy evaluates and test the policy ensuring if the privileged parameter in the container definition is set to `false`. |
