### PR TITLE
feat: `validate-ecs-container-insights-enabled` policy

### DIFF
--- a/validate-ecs-container-insights-enabled/README.md
+++ b/validate-ecs-container-insights-enabled/README.md
@@ -1,0 +1,87 @@
+# Validate ECS Container Insights Policy
+
+Container Insights plays a crucial role in AWS ECS by providing diagnostic information, including details about container restart failures, aiding in the quick identification and resolution of issues. This policy, "validate-ecs-container-insights-enabled," ensures that ECS clusters have Container Insights enabled for effective monitoring and issue isolation.
+
+## Policy Details:
+
+- **Policy Name:** validate-ecs-container-insights-enabled
+- **Check Description:** Verify if ECS clusters have Container Insights enabled.
+
+## Why it Matters:
+
+Container Insights enhances the operational visibility of ECS clusters, allowing for proactive issue resolution. Enabling this feature ensures that diagnostic information is readily available, contributing to a more efficient and reliable containerized environment.
+
+## How It Works:
+
+The policy checks the ECS clusters to confirm whether Container Insights are enabled. If Container Insights are not set up for a cluster, the policy marks it as non-compliant.
+
+### Validation Criteria:
+
+- **Condition:** `containerInsights` is set to `enabled`
+  - **Result:** PASS
+
+- **Condition:** `containerInsights` is set to `disabled`
+  - **Result:** FAIL
+
+- **Condition:** `containerInsights` is not present
+  - **Result:** FAIL
+
+### Policy Validation Testing Instructions
+
+To evaluate and test the policy, follow the steps outlined below:
+
+Make sure you have `kyverno-json` installed on the machine 
+
+1. **Initialize Terraform:**
+    ```
+    terraform init
+    ```
+
+2. **Create Binary Terraform Plan:**
+    ```
+    terraform plan -out tfplan.binary
+    ```
+
+3. **Convert Binary to JSON Payload:**
+    ```
+    terraform show -json tfplan.binary | jq > payload.json
+    ```
+
+4. **Test the Policy with Kyverno:**
+    ```
+   kyverno-json scan --payload payload.json --policy policy.yaml
+    ```
+
+    a. **Test Policy Against Valid Payload:**
+    ```
+    kyverno-json scan --policy validate-ecs-container-insights-enabled.yaml --payload policy-test/good-payload.json
+    ```
+
+    This produces the output:
+    ```
+    Loading policies ...
+    Loading payload ...
+    Pre processing ...
+    Running ( evaluating 1 resource against 1 policy ) ...
+    - validate-ecs-container-insights-enabled / container-insights /  PASSED
+    Done
+    ```
+
+    b. **Test Against Invalid Payload:**
+    ```
+    kyverno-json scan --policy validate-ecs-container-insights-enabled.yaml --payload policy-test/bad-payload.json
+    ```
+
+    This produces the output:
+    ```
+    Loading policies ...
+    Loading payload ...
+    Pre processing ...
+    Running ( evaluating 1 resource against 1 policy ) ...
+    - validate-ecs-container-insights-enabled / container-insights /  FAILED: ECS container insights are not enabled: [all[0].check.~.(planned_values.root_module.resources[?type == 'aws_ecs_cluster'])[0].values.(length(setting[?name=='containerInsights'] || `[]`) > `0`): Invalid value: false: Expected value: true, all[0].check.~.(planned_values.root_module.resources[?type == 'aws_ecs_cluster'])[0].values.(!setting): Invalid value: true: Expected value: false]
+    Done
+    ```
+
+---
+
+By enforcing this policy, you ensure that ECS clusters adhere to best practices in containerized environments by leveraging the capabilities of Container Insights for effective monitoring and issue resolution.

--- a/validate-ecs-container-insights-enabled/policy-test/bad-payload.json
+++ b/validate-ecs-container-insights-enabled/policy-test/bad-payload.json
@@ -1,0 +1,111 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.7.0-dev",
+    "planned_values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_ecs_cluster.foo",
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "foo",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "configuration": [],
+              "name": "white-hart",
+              "service_connect_defaults": [],
+              "tags": null
+            },
+            "sensitive_values": {
+              "capacity_providers": [],
+              "configuration": [],
+              "default_capacity_provider_strategy": [],
+              "service_connect_defaults": [],
+              "setting": [],
+              "tags_all": {}
+            }
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "aws_ecs_cluster.foo",
+        "mode": "managed",
+        "type": "aws_ecs_cluster",
+        "name": "foo",
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "configuration": [],
+            "name": "white-hart",
+            "service_connect_defaults": [],
+            "tags": null
+          },
+          "after_unknown": {
+            "arn": true,
+            "capacity_providers": true,
+            "configuration": [],
+            "default_capacity_provider_strategy": true,
+            "id": true,
+            "service_connect_defaults": [],
+            "setting": true,
+            "tags_all": true
+          },
+          "before_sensitive": false,
+          "after_sensitive": {
+            "capacity_providers": [],
+            "configuration": [],
+            "default_capacity_provider_strategy": [],
+            "service_connect_defaults": [],
+            "setting": [],
+            "tags_all": {}
+          }
+        }
+      }
+    ],
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "full_name": "registry.terraform.io/hashicorp/aws",
+          "version_constraint": "~> 4.0",
+          "expressions": {
+            "region": {
+              "constant_value": "us-west-1"
+            }
+          }
+        },
+        "docker": {
+          "name": "docker",
+          "full_name": "registry.terraform.io/kreuzwerker/docker",
+          "version_constraint": "~> 2.20.0"
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_ecs_cluster.foo",
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "foo",
+            "provider_config_key": "aws",
+            "expressions": {
+              "name": {
+                "constant_value": "white-hart"
+              }
+            },
+            "schema_version": 0
+          }
+        ]
+      }
+    },
+    "timestamp": "2024-01-18T17:47:42Z",
+    "errored": false
+  }
+  

--- a/validate-ecs-container-insights-enabled/policy-test/good-payload.json
+++ b/validate-ecs-container-insights-enabled/policy-test/good-payload.json
@@ -1,0 +1,139 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.7.0-dev",
+    "planned_values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_ecs_cluster.foo",
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "foo",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "configuration": [],
+              "name": "white-hart",
+              "service_connect_defaults": [],
+              "setting": [
+                {
+                  "name": "containerInsights",
+                  "value": "enabled"
+                }
+              ],
+              "tags": null
+            },
+            "sensitive_values": {
+              "capacity_providers": [],
+              "configuration": [],
+              "default_capacity_provider_strategy": [],
+              "service_connect_defaults": [],
+              "setting": [
+                {}
+              ],
+              "tags_all": {}
+            }
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "aws_ecs_cluster.foo",
+        "mode": "managed",
+        "type": "aws_ecs_cluster",
+        "name": "foo",
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "configuration": [],
+            "name": "white-hart",
+            "service_connect_defaults": [],
+            "setting": [
+              {
+                "name": "containerInsights",
+                "value": "enabled"
+              }
+            ],
+            "tags": null
+          },
+          "after_unknown": {
+            "arn": true,
+            "capacity_providers": true,
+            "configuration": [],
+            "default_capacity_provider_strategy": true,
+            "id": true,
+            "service_connect_defaults": [],
+            "setting": [
+              {}
+            ],
+            "tags_all": true
+          },
+          "before_sensitive": false,
+          "after_sensitive": {
+            "capacity_providers": [],
+            "configuration": [],
+            "default_capacity_provider_strategy": [],
+            "service_connect_defaults": [],
+            "setting": [
+              {}
+            ],
+            "tags_all": {}
+          }
+        }
+      }
+    ],
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "full_name": "registry.terraform.io/hashicorp/aws",
+          "version_constraint": "~> 4.0",
+          "expressions": {
+            "region": {
+              "constant_value": "us-west-1"
+            }
+          }
+        },
+        "docker": {
+          "name": "docker",
+          "full_name": "registry.terraform.io/kreuzwerker/docker",
+          "version_constraint": "~> 2.20.0"
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_ecs_cluster.foo",
+            "mode": "managed",
+            "type": "aws_ecs_cluster",
+            "name": "foo",
+            "provider_config_key": "aws",
+            "expressions": {
+              "name": {
+                "constant_value": "white-hart"
+              },
+              "setting": [
+                {
+                  "name": {
+                    "constant_value": "containerInsights"
+                  },
+                  "value": {
+                    "constant_value": "enabled"
+                  }
+                }
+              ]
+            },
+            "schema_version": 0
+          }
+        ]
+      }
+    },
+    "timestamp": "2024-01-18T15:48:00Z",
+    "errored": false
+  }
+  

--- a/validate-ecs-container-insights-enabled/policy-test/terraform-code/main.tf
+++ b/validate-ecs-container-insights-enabled/policy-test/terraform-code/main.tf
@@ -1,0 +1,8 @@
+resource "aws_ecs_cluster" "foo" {
+  name = "white-hart"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}

--- a/validate-ecs-container-insights-enabled/policy-test/terraform-code/provider.tf
+++ b/validate-ecs-container-insights-enabled/policy-test/terraform-code/provider.tf
@@ -1,0 +1,22 @@
+# Setting up the configuration for using Docker and AWS providers
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.20.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Configuring docker and AWS as providers
+provider "docker" {}
+
+provider "aws" {
+  region  = "us-west-1"
+}
+

--- a/validate-ecs-container-insights-enabled/validate-ecs-container-insights-enabled.yaml
+++ b/validate-ecs-container-insights-enabled/validate-ecs-container-insights-enabled.yaml
@@ -1,0 +1,29 @@
+apiVersion: json.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: validate-ecs-container-insights-enabled
+  labels:
+    ecs.aws.tags.kyverno.io: ecs-cluster
+  annotations:
+    policies.kyverno.io/title: Validate ECS container insights are enabled
+    policies.kyverno.io/category: ECS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      This Policy ensures that ECS clusters have container
+      insights enabled.
+    policies.nirmata.io/remediation-docs: ""
+    policies.nirmata.io/remediation: ""
+spec:
+  rules:
+    - name: container-insights
+      assert:
+        all:
+        - message: ECS container insights are not enabled
+          check:
+            ~.(planned_values.root_module.resources[?type == 'aws_ecs_cluster']):
+                values:
+                    (!setting): false
+                    (length(setting[?name=='containerInsights'] || `[]`) > `0`): true
+                    ~.(setting[?name=='containerInsights'] || `[]`):
+                        value: enabled
+                        


### PR DESCRIPTION
| Category                | AWS ECS Best Practices       | 
|-----------------------------------|-----------------------------| 
| Policy                  | validate-ecs-container-insights-enabled  | 
| Rule                    | validate-ecs-container-insights-enabled  | 
| Severity                | medium                      | 
| Description            | Container Insights provides diagnostic information, such as container restart failures, to help you isolate issues and resolve them quickly. This policy validates if ECS container insights is enabled for your task. |
